### PR TITLE
setImmediate + requestAnimationFrame before flip animation

### DIFF
--- a/index.js
+++ b/index.js
@@ -97,14 +97,18 @@ class FlipView extends Component {
 
     var {frontRotation, backRotation} = this._getTargetRenderStateFromFlippedValue(nextIsFlipped);
 
-    Animated.parallel([this._animateValue(this.state.frontRotationAnimatedValue, frontRotation, this.props.flipEasing),
-      this._animateValue(this.state.backRotationAnimatedValue, backRotation, this.props.flipEasing)]
-    ).start(k => {
-      if (!k.finished) {
-        return;
-      }
-      this.setState({isFlipped: nextIsFlipped});
-      this.props.onFlipped(nextIsFlipped);
+    setImmediate(() => {
+      requestAnimationFrame(() => {
+        Animated.parallel([this._animateValue(this.state.frontRotationAnimatedValue, frontRotation, this.props.flipEasing),
+          this._animateValue(this.state.backRotationAnimatedValue, backRotation, this.props.flipEasing)]
+        ).start(k => {
+          if (!k.finished) {
+            return;
+          }
+          this.setState({isFlipped: nextIsFlipped});
+          this.props.onFlipped(nextIsFlipped);
+        });
+      });
     });
   };
 


### PR DESCRIPTION
when you're clipping the front or the back before/after flips, re-rendering can mess up the animation and this fixes it. 

...im also about to supply the clipping feature as an option/prop built-into this component. If you're just flipping a card, it doesn't matter much, but if you're flipping the entire app (say, from a Tour to the main panel of the app like I am), you won't want both sides rendered if you're not using them both at the same time. 
